### PR TITLE
Consider leading v for special cases.

### DIFF
--- a/lib/CPAN/DistnameInfo.pm
+++ b/lib/CPAN/DistnameInfo.pm
@@ -24,7 +24,7 @@ sub distname_info {
   # Remove potential -withoutworldwriteables suffix
   $version =~ s/-withoutworldwriteables$//;
 
-  if ($version =~ /^(-[Vv].*)-(\d.*)/) {
+  if ($version =~ /^(-[Vv].*)-(v?\d.*)/) {
    
     # Catch names like Unicode-Collate-Standard-V3_1_1-0.1
     # where the V3_1_1 is part of the distname
@@ -32,7 +32,7 @@ sub distname_info {
     $version = $2;
   }
 
-  if ($version =~ /(.+_.*)-(\d.*)/) {
+  if ($version =~ /(.+_.*)-(v?\d.*)/) {
       # Catch names like Task-Deprecations5_14-1.00.tar.gz where the 5_14 is
       # part of the distname. However, names like libao-perl_0.03-1.tar.gz
       # should still have 0.03-1 as their version.

--- a/t/ext.t
+++ b/t/ext.t
@@ -1,5 +1,5 @@
 
-use Test::More tests => 560;
+use Test::More tests => 562;
 use Data::Dumper;
 
 use CPAN::DistnameInfo;
@@ -575,3 +575,5 @@ Net-Vypress-Chat-0.72.1.tar.bz2 Net-Vypress-Chat 0.72.1
 Gopher-Server-0.1.1.tar.bz2 Gopher-Server 0.1.1
 HTML-Template-Dumper-0.1.tar.bz2 HTML-Template-Dumper 0.1
 Task-Deprecations5_14-1.00.tar.gz	Task-Deprecations5_14	1.00
+Software-License-Boost_1_0-v0.0.1.tar.gz	Software-License-Boost_1_0	v0.0.1
+Test-Kwalitee-Extra-v0.0.6.tar.gz	Test-Kwalitee-Extra	v0.0.6


### PR DESCRIPTION
Special cases like the following names have been already handled in this module:
- Unicode-Collate-Standard-V3_1_1-0.1
- Task-Deprecations5_14-1.00.tar.gz

I think version with leading-v  is also valid module version as described in .http://search.cpan.org/perldoc?version
So, leading-v should be considered in these special cases, shouldn't it?

Actually, it fails to parse my module Software-License-Boost_1_0-v0.0.1.tar.gz

I adjusted regexp for special cases and added 2 test cases for version with leading-v, also.

Thank you.
