### PR TITLE
misc. patches from the 2014 QA Hackathon

### DIFF
--- a/lib/CPAN/DistnameInfo.pm
+++ b/lib/CPAN/DistnameInfo.pm
@@ -63,7 +63,7 @@ sub distname_info {
     if ($file =~ /^perl-?\d+\.(\d+)(?:\D(\d+))?(-(?:TRIAL|RC)\d+)?$/) {
       $dev = 1 if (($1 > 6 and $1 & 1) or ($2 and $2 >= 50)) or $3;
     }
-    elsif ($version =~ /\d\D\d+_\d/ or $version =~ s/-TRIAL$//) {
+    elsif ($version =~ /\d\D\d+_\d/ or $version =~ s/-TRIAL[0-9]*$//) {
       $dev = 1;
     }
   }

--- a/t/ext.t
+++ b/t/ext.t
@@ -1,5 +1,5 @@
 
-use Test::More tests => 561;
+use Test::More tests => 563;
 use Data::Dumper;
 
 use utf8;
@@ -582,3 +582,4 @@ HTML-Template-Dumper-0.1.tar.bz2	HTML-Template-Dumper	0.1
 Task-Deprecations5_14-1.00.tar.gz	Task-Deprecations5_14	1.00
 Foo-Bar-1.0௧.tar.gz	Foo-Bar-1.0௧
 Foo-Bar-1.0-TRIAL.tar.gz	Foo-Bar	1.0	1
+Foo-Bar-1.0-TRIAL2.tar.gz	Foo-Bar	1.0	1


### PR DESCRIPTION
- fixes some test cases that were not testing due to incorrect format
- refuse to parse ASCII distnames (PAUSE will not accept them anyway and avoids problems with `\d` accepting things like ૪
- fixes -TRIAL handling so that Foo-1.0-TRIAL is version 1.0, not version 1.0-TRIAL

I've discussed these changes with many of the consumers of this data here at the hackathon, for whatever that's worth.
