### PR TITLE
Fix test failure

### DIFF
--- a/lib/CPAN/DistnameInfo.pm
+++ b/lib/CPAN/DistnameInfo.pm
@@ -63,7 +63,7 @@ sub distname_info {
     if ($file =~ /^perl-?\d+\.(\d+)(?:\D(\d+))?(-(?:TRIAL|RC)\d+)?$/) {
       $dev = 1 if (($1 > 6 and $1 & 1) or ($2 and $2 >= 50)) or $3;
     }
-    elsif ($version =~ /\d\D\d+_\d/ or $version =~ s/-TRIAL[0-9]*$//) {
+    elsif ($version =~ /\d\D\d+_\d/ or $version =~ /-TRIAL[0-9]*$/) {
       $dev = 1;
     }
   }

--- a/t/ext.t
+++ b/t/ext.t
@@ -581,5 +581,5 @@ Gopher-Server-0.1.1.tar.bz2	Gopher-Server	0.1.1
 HTML-Template-Dumper-0.1.tar.bz2	HTML-Template-Dumper	0.1
 Task-Deprecations5_14-1.00.tar.gz	Task-Deprecations5_14	1.00
 Foo-Bar-1.0௧.tar.gz	Foo-Bar-1.0௧
-Foo-Bar-1.0-TRIAL.tar.gz	Foo-Bar	1.0	1
-Foo-Bar-1.0-TRIAL2.tar.gz	Foo-Bar	1.0	1
+Foo-Bar-1.0-TRIAL.tar.gz	Foo-Bar	1.0-TRIAL	1
+Foo-Bar-1.0-TRIAL2.tar.gz	Foo-Bar	1.0-TRIAL2	1


### PR DESCRIPTION
The git repo code would not pass make test.  I've fixed that.

The code was stripping -TRIAL (but not -TRIAL3) from the version number - I removed the stripping action, thus allowing it to pass path.t.  However, that made it fail ext.t instead (which expected -TRIAL.\* to be removed).  Looking at the version on CPAN, -TRIAL was present there and not stripped, and the tests that failed after the change back were not present in ext.t.  I also think that the -TRIAL indicator could be significant as part of the version, so I think this is the right fix.

However, if it's not, and it should be stripped, let me know and I'll be glad to submit a PR with that in mind instead.

FYI this submission is part of the CPAN Pull Request Challenge - I was assigned your module for August.
